### PR TITLE
Render asset urls to absURL

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -103,9 +103,9 @@
 
         {{ if .Site.Params.localTime }}
         <p>My current local time is <span id="time"></span>.</p>
-        <script type="text/javascript" src="/js/moment.js"></script>
-        <script type="text/javascript" src="/js/moment-timezone.js"></script>
-        <script type="text/javascript" src="/js/moment-timezone-with-data-2012-2022.js"></script>
+        <script type="text/javascript" src={{ "js/moment.js" | absURL }}></script>
+        <script type="text/javascript" src={{ "js/moment-timezone.js" | absURL }}></script>
+        <script type="text/javascript" src={{ "js/moment-timezone-with-data-2012-2022.js" | absURL }}></script>
 
         <script>
         $(document).ready(function() {

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -34,17 +34,16 @@
 {{ end }}
 
 <!-- jQuery -->
-<script type="text/javascript" src="/js/jquery-3.3.1.min.js"></script>
+<script type="text/javascript" src={{ "js/jquery-3.3.1.min.js"| absURL }}></script>
 
 <!-- Fonts and icon CSS -->
-<link rel="stylesheet" href="/css/font-awesome.min.css">
-<link rel="stylesheet" href="/css/nunito_sans.css">
+<link rel="stylesheet" href={{ "css/font-awesome.min.css" | absURL }}>
+<link rel="stylesheet" href={{ "css/nunito_sans.css" | absURL }}>
 
 {{ if .Site.Params.cacheBuster }}
-    {{ $t := now.Unix }}
-    <link rel="stylesheet" href="css/{{ .Site.Params.themeStyle | default "dark" }}-style.css?t={{$t}}">
+    <link rel="stylesheet" href="{{ (printf "css/%s-style.css?t=%d" (.Site.Params.themeStyle | default "dark") now.Unix) |relURL }}">
 {{ else }}
-    <link rel="stylesheet" href="css/{{ .Site.Params.themeStyle | default "dark" }}-style.css">
+    <link rel="stylesheet" href="{{ (printf "css/%s-style.css" .Site.Params.themeStyle | default "dark") | absURL }}">
 {{ end }}
 
 <!-- Custom css -->
@@ -53,7 +52,7 @@
 {{- end }}
 
 <!-- Icon -->
-<link rel="shortcut icon" href="{{ .Site.Params.faviconFile | default "img/favicon.ico" }}">
+<link rel="shortcut icon" href="{{ .Site.Params.faviconFile | default "img/favicon.ico" | absURL }}">
 
 <!-- Google Analytics -->
 {{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
This fixes a bug if the baseURL is set to `https://example.org/test/`