### PR TITLE
Base config files

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,14 +1,12 @@
-baseurl                 = "/"   # Your domain name. Must end with "/"
-languageCode            = "en-us"
-title                   = "Introduction"
+baseURL                 = "https://example.org/"            # Your domain name. Must end with "/"
+languageCode            = "en-us"                           # languageCode
+title                   = "Introduction"                    # Site title
 theme                   = "introduction"
 enforce_ssl             = false
-builddrafts             = false                             # Include pages with draft status of true
-canonifyurls            = true                              # Turns relative urls into absolute urls
-# disqusshortname       = "xxx"                             # Enable Disqus for comments
-# googleAnalytics       = "xxx"
+# disqusshortname       = ""                                # Enable Disqus for comments https://gohugo.io/content-management/comments
+# googleAnalytics       = ""                                # Enable Google Analytics https://gohugo.io/templates/internal/#google-analytics
 
-[params]    
+[params]
     blogHead            = "Blog"                            # Full name shows on blog post pages
     firstName           = "Introduction"                    # First name shows in introduction on main page
     tagLine             = "I'm a theme for Hugo."           # Appears after the introduction
@@ -47,13 +45,13 @@ canonifyurls            = true                              # Turns relative url
 # Find icon names here: http://fontawesome.io/cheatsheet/
 
 [[params.social]]
-    url = "https://twitter.com/"
+    url  = "https://twitter.com/"
     icon = "twitter"
 
 [[params.social]]
-    url = "https://facebook.com/"
+    url  = "https://facebook.com/"
     icon = "facebook"
 
 [[params.social]]
-    url = "https://linkedin.com/"
+    url  = "https://linkedin.com/"
     icon = "linkedin"

--- a/theme.toml
+++ b/theme.toml
@@ -1,6 +1,3 @@
-# theme.toml template for a Hugo theme
-# See https://github.com/gohugoio/hugoThemes#themetoml for an example
-
 name = "Introduction"
 license = "Creative Commons Attribution 3.0 Unported"
 licenselink = "https://github.com/vickylai/hugo-theme-introduction/blob/master/LICENSE.md"
@@ -13,9 +10,3 @@ min_version = "0.30"
 [author]
   name = "Vicky Lai"
   homepage = "https://vickylai.com"
-
-# If porting an existing theme
-[original]
-  name = ""
-  homepage = ""
-  repo = ""


### PR DESCRIPTION
This PR cleans up both config files. But it also has some changes:
- `baseurl` is now set to `https://example.org/` just like for a new hugo site
- Removed `canonifyurls = true`. If someone really needs this option, he/she can add it by her/his self. There is not need to provide this by default.