### PR TITLE
image relURL on single pages (address #69)

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -23,7 +23,7 @@
                 <!-- Begin content -->
                 {{ if .Params.image }}
                 <div class="has-text-centered">
-                    <img src="{{ .Params.image }}" class="img-responsive">
+                    <img src="{{ .Params.image | relURL }}" class="img-responsive">
                 </div>
                 {{ end }} {{ .Content }}
             </div>


### PR DESCRIPTION
Images in static directory were not displaying on single pages within the /projects/ folder. Including of relURL makes them appear.