### PR TITLE
Fix smooth scrolling for footnotes

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -22,7 +22,7 @@ document.addEventListener("DOMContentLoaded", function () {
 $("a[href^=\"#\"]").click(function(e) {
     e.preventDefault();
     $("html, body").animate({
-        scrollTop: $(this.hash).offset().top
+        scrollTop: $(document.getElementById(this.hash.substr(1))).offset().top
     }, 500);
     $("#nav-menu").removeClass("is-active");
     return true;


### PR DESCRIPTION
Footnotes are using a fragment format with a colon inside ("#fn:1" for
example). However, ":" is a special character for jQuery
(http://api.jquery.com/category/selectors/), thus the target anchor is
never found and the scrolling does not happen.

This change selects the right target element using vanilla Javascript to
bypass special characters that could be in the fragment part.

An alternative way to fix the issue would be to escape any
meta-character in the fragment string before sending it to jQuery.