### PR TITLE
Add HTML attributes to social links (fixes #121)

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -53,6 +53,11 @@ DefaultContentLanguage           = "en"                    # Default language fo
         url = "mailto:youremail@email.com"  # For a direct email link, use "mailto:test@example.org".
         icon = "paper-plane" # icon name without the 'fa-'
         icon_pack = "fas"
+    [[params.social]]
+        url   = "https://mastodon.social/"
+        icon  = "mastodon" # icon name without the 'fa-'
+        icon_pack = "fab"
+        html_attributes = "rel=\"me\"" # Add rel attribute for Mastodon profile link verification
 
 
 # If you don't want to use the default menu, you can define one by yourself

--- a/layouts/partials/home/social.html
+++ b/layouts/partials/home/social.html
@@ -1,6 +1,6 @@
 <div class="social-icons">
     {{ range .Site.Params.social }}
-    <a href="{{ .url }}">
+    <a href="{{ .url }}" {{ .html_attributes | safeHTMLAttr }}>
         <i class="{{ .icon_pack}} fa-{{ .icon}}"></i>
     </a>
     {{ end }}


### PR DESCRIPTION
* Insert arbitrary HTML attributes to social links via config.toml

(fixes #121)

---

I can't find anything that looks like tests, do I have to add any?